### PR TITLE
Add option for config file in local project.

### DIFF
--- a/tasks/coffeelint.js
+++ b/tasks/coffeelint.js
@@ -3,12 +3,14 @@ module.exports = function(grunt) {
 
   grunt.registerMultiTask('coffeelint', 'Validate files with CoffeeLint', function() {
 
-    var files = this.filesSrc;
-    var options = this.options({
-      force: false,
-    });
     var errorCount = 0;
     var warnCount = 0;
+    var files = this.filesSrc;
+    var options = this.options();
+
+    if (options.config != undefined) {
+        options = grunt.file.readJSON(options.config);
+    }
 
     files.forEach(function(file) {
       grunt.verbose.writeln('Linting ' + file + '...');


### PR DESCRIPTION
This is a simple patch to allow use of a config file to load all options similar to jshintrc (to keep from cluttering my gruntfile with too many config options).
