### PR TITLE
Allow config file for lint options

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -33,5 +33,7 @@ module.exports = (grunt) ->
   # Default task.
   grunt.registerTask 'default', 'coffeelint'
 
+  grunt.registerTask 'test', 'coffeelint'
+
   grunt.registerTask 'release', 'Bump version, push to NPM.', (type)-> 
     grunt.task.run ["bump: #{type || 'patch'}",'npm-publish']

--- a/tasks/coffeelint.js
+++ b/tasks/coffeelint.js
@@ -9,12 +9,12 @@ module.exports = function(grunt) {
     var options = this.options();
 
     if (options.configFile != undefined) {
-        var config = grunt.file.readJSON(options.configFile);
-        options.configFile = undefined;
-        for (var key in options) {
-            config[key] = options[key];
-        }
-        options = config;
+      var config = grunt.file.readJSON(options.configFile);
+      options.configFile = undefined;
+      for (var key in options) {
+          config[key] = options[key];
+      }
+      options = config;
     }
 
     files.forEach(function(file) {
@@ -53,8 +53,7 @@ module.exports = function(grunt) {
     }
 
     if (!warnCount) {
-      grunt.log.ok(files.length + ' file' + (files.length === 1 ? '' : 's') +
-          ' lint free.');
+      grunt.log.ok(files.length + ' file' + (files.length === 1 ? '' : 's') + ' lint free.');
     }
   });
 };


### PR DESCRIPTION
Allow config file for lint options, with grunt task options having precedence over config file options.

``` javascript
coffeelint: { 
   options: { 
      // project level config of lint options for coffeescript.
      configFile: 'coffeelint.json',
      // global options override config file options
      no_implicit_braces:     { level: "ignore" },
      indentation: { level: "error", value: 2 }
   }, 
   src: { 
     // target options override global options
      options: {  
         indentation: { level: "error", value: 4 }
      }, 
      files: { 
          src: [...]
      }
   },
   test: {
      // no target options, accept the global options
      files: { 
          src: [...]
      }
   }
},
```
