### PR TITLE
Added *.litcoffee support

### DIFF
--- a/tasks/coffeelint.js
+++ b/tasks/coffeelint.js
@@ -13,7 +13,8 @@ module.exports = function(grunt) {
     files.forEach(function(file) {
       grunt.verbose.writeln('Linting ' + file + '...');
 
-      var errors = coffeelint.lint(grunt.file.read(file), options);
+      var literate = file.indexOf(".litcoffee") !== -1;
+      var errors = coffeelint.lint(grunt.file.read(file), options, literate);
 
       if (!errors.length) {
         return grunt.verbose.ok();


### PR DESCRIPTION
Version 0.5.7 of Coffeelint adds support for .litcoffee files: https://github.com/clutchski/coffeelint/commit/c495246121cd8142ba80d7f8ec9f027e3f969fff.

This checks to see if the file is litcoffee and passes in the appropriate flag.
