### PR TITLE
Fixing `resolve` entry point.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
       "url": "http://github.com/vojtajina/grunt-coffeelint/blob/master/LICENSE-"
     }
   ],
-  "main": "grunt.js",
+  "main": "Gruntfile.coffee",
   "engines": {
     "node": "*"
   },


### PR DESCRIPTION
`package.json` lists the main entry point as `grunt.js`, which does not exist within the package. This is breaking `resolve( )`, as the lookup fails due to a not-found file. Changing `package` to `Gruntfile.coffee`, which is the actual file name, fixes the issue.

Though Grunt has no need for `resolve`, the lookup is used by some Grunt plugins, such as LinemanJS, to identify nested plugins and Grunt tasks.
