### PR TITLE
use coffeelint@1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "grunt": "~0.4"
   },
   "dependencies": {
-    "coffeelint": "~1.1",
+    "coffeelint": "~1.2.0",
     "coffeelint-stylish": "~0.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
coffeelint@1.2.0 fixes some strange bugs (e.g. this one https://github.com/clutchski/coffeelint/issues/215) . 

would be great to use this version in grunt-coffeelint (and publish it to npm!)
