### PR TITLE
Remove extra open brace from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ grunt.initConfig({
     ...
     coffeelint: {
       app: ['app/*.coffee', 'scripts/*.coffee']
-      }
     },
     ...
 });


### PR DESCRIPTION
There's an extra brace in README.md. This commit removes it.
