### PR TITLE
Update coffeelint-stylish reporter

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "coffeelint": "~1.1",
-    "coffeelint-stylish": "~0.0.1"
+    "coffeelint-stylish": "~0.1.0"
   },
   "devDependencies": {
     "grunt": "~0.4",


### PR DESCRIPTION
`coffeelint-stylish` just got a bit more stable :). Now bug fixes to the reporter will be easy to deliver. There were no changes to the runtime which is used in `grunt-coffeelint`. Hence this is not a critical update at the moment.
