### PR TITLE
Add hook to register a custom linter rule.

### DIFF
--- a/tasks/coffeelint.js
+++ b/tasks/coffeelint.js
@@ -18,6 +18,10 @@ module.exports = function(grunt) {
       options = config;
     }
 
+    if (options.registerRule != undefined) {
+      coffeelint.registerRule(options.registerRule)
+    }
+
     files.forEach(function(file) {
       grunt.verbose.writeln('Linting ' + file + '...');
 


### PR DESCRIPTION
This allows you to write a rule and register it. 
