### PR TITLE
Add support for .coffeelintignore files

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "coffeelint": "^1"
   },
   "dependencies": {
-    "coffeelint-stylish": "~0.1.0"
+    "coffeelint-stylish": "~0.1.0",
+    "ignore": "^2.2.15"
   },
   "devDependencies": {
     "grunt": "~0.4",

--- a/tasks/coffeelint.js
+++ b/tasks/coffeelint.js
@@ -1,6 +1,7 @@
 module.exports = function(grunt) {
   var coffeelint = require('coffeelint');
   var reporter = require('coffeelint-stylish').reporter;
+  var ignore = require('ignore');
 
   grunt.registerMultiTask('coffeelint', 'Validate files with CoffeeLint', function() {
 
@@ -17,6 +18,9 @@ module.exports = function(grunt) {
       }
       options = config;
     }
+
+    // Exclude files in .coffeelintignore
+    files = ignore().addIgnoreFile('.coffeelintignore').filter(files);
 
     files.forEach(function(file) {
       grunt.verbose.writeln('Linting ' + file + '...');


### PR DESCRIPTION
Coffeelint now supports `.coffeelintignore` files with the same semantics as `.gitignore`. Unfortunately, since we're calling `coffeelint.lint` directly, we have to implement this logic here rather than in coffeelint.

Adds a dependency on the [ignore](https://www.npmjs.com/package/ignore) package.
